### PR TITLE
fix: use createRoot instead of ReactDOM.render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import App from './components/App';
 import './index.css';
 
-ReactDOM.render(<App />, document.querySelector('#root'));
+const el = document.getElementById('root');
+const root = ReactDOM.createRoot(el);
+
+root.render(<App />);


### PR DESCRIPTION
ReactDOM.render is no longer supported in React 18. Use createRoot instead.